### PR TITLE
change interface name

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -7,6 +7,6 @@ type QueryExt struct {
 	SeekPrefix string
 }
 
-type ExtendedDatastore interface {
+type QueryExtensions interface {
 	QueryExtended(q QueryExt) (query.Results, error)
 }


### PR DESCRIPTION
Changes `ExtendedDatastore` to `QueryExtensions` that applying the interface to txns makes more sense. 