### PR TITLE
Requires newtransactionextended

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -1,10 +1,23 @@
 package dsextensions
 
-import "github.com/ipfs/go-datastore/query"
+import (
+	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/query"
+)
 
 type QueryExt struct {
 	query.Query
 	SeekPrefix string
+}
+
+type TxnExt interface {
+	datastore.Txn
+	QueryExtensions
+}
+
+type DatastoreExtensions interface {
+	NewTransactionExtended(readOnly bool) (TxnExt, error)
+	QueryExtensions
 }
 
 type QueryExtensions interface {


### PR DESCRIPTION
Unless you want to type assert `Txn` in order to access `QueryExtended`, we'll have to return a more specific type like this.